### PR TITLE
Add a `__name__` to the class definition

### DIFF
--- a/src/click_loglevel/__init__.py
+++ b/src/click_loglevel/__init__.py
@@ -48,6 +48,7 @@ class LogLevel(click.ParamType):
 
     name = "log-level"
     LEVELS = ["NOTSET", "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+    __name__ = name
 
     def __init__(self, extra: Iterable[str] | Mapping[str, int] | None = None) -> None:
         self.levels: dict[str, int] = {lv: getattr(logging, lv) for lv in self.LEVELS}


### PR DESCRIPTION
async-click uses `__name__` not `name` for generating the help text

---

Should fix/address #9 
